### PR TITLE
feat: Configurable server settings

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -34,5 +34,8 @@ export default defineConfig({
                 rewrite: (path) => path.replace(/^\/api/, ""),
             },
         },
+        host: process.env.VITE_HOST || "localhost",
+        port: process.env.VITE_PORT || 5173,
+        strictPort: true,
     },
 });


### PR DESCRIPTION
Added few settings to `vite.config.ts` to make it possible to run the client as a service without additional workarounds, in particular for listening on `any` address.