### PR TITLE
Fix: remove hardcoded branch name when committing changes

### DIFF
--- a/packages/plugin-github/src/plugins/createCommit.ts
+++ b/packages/plugin-github/src/plugins/createCommit.ts
@@ -87,20 +87,20 @@ export const createCommitAction: Action = {
         const repoPath = getRepoPath(content.owner, content.repo);
 
         try {
-            await checkoutBranch(repoPath, "realitySpiral/demoPR", true);
+            await checkoutBranch(repoPath, content.branch, true);
             await writeFiles(repoPath, content.files);
             const commit = await commitAndPushChanges(
                 repoPath,
                 content.message,
-                "realitySpiral/demoPR"
+                content.branch
             );
             const hash = commit.commit;
             elizaLogger.info(
-                `Commited changes to the repository ${content.owner}/${content.repo} successfully to branch 'realitySpiral/demoPR'! commit hash: ${hash}`
+                `Commited changes to the repository ${content.owner}/${content.repo} successfully to branch '${content.branch}'! commit hash: ${hash}`
             );
             if (callback) {
                 callback({
-                    text: `Changes commited to repository ${content.owner}/${content.repo} successfully to branch 'realitySpiral/demoPR'! commit hash: ${hash}`,
+                    text: `Changes commited to repository ${content.owner}/${content.repo} successfully to branch '${content.branch}'! commit hash: ${hash}`,
                     attachments: [],
                 });
             }

--- a/packages/plugin-github/src/plugins/interactWithPR.ts
+++ b/packages/plugin-github/src/plugins/interactWithPR.ts
@@ -1096,7 +1096,7 @@ export const implementFeatureAction: Action = {
                 JSON.stringify(codeFileChangesContent, null, 2)
             );
 
-            message.content.text = `Commit changes to the repository ${content.owner}/${content.repo} on branch realitySpiral/demoPR with the commit message: ${content.feature}`;
+            message.content.text = `Commit changes to the repository ${content.owner}/${content.repo} on branch '${content.branch}' with the commit message: ${content.feature}`;
 
             // Commit changes
             const commit = await createCommitAction.handler(


### PR DESCRIPTION
Replaced hardcoded `realitySpiral/demoPR` branch with correct current branch variable